### PR TITLE
feat: add skill behavior testing — verify skills work correctly, not just structurally

### DIFF
--- a/.github/workflows/skill-behavior-tests.yml
+++ b/.github/workflows/skill-behavior-tests.yml
@@ -1,0 +1,62 @@
+name: Skill Behavior Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "*/skills/**"
+      - "tests/**"
+      - ".github/workflows/skill-behavior-tests.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "*/skills/**"
+      - "tests/**"
+      - ".github/workflows/skill-behavior-tests.yml"
+  workflow_dispatch:
+
+jobs:
+  behavior-tests:
+    name: Run skill behavior tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install EvalView
+        run: pip install "evalview>=0.4.0"
+
+      - name: Validate skill structure (existing check)
+        run: python validate_plugins.py
+
+      - name: Run behavior tests — pm-toolkit
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          evalview skill test tests/pm-toolkit/grammar-check.yaml --no-open
+
+      - name: Run behavior tests — pm-execution
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          evalview skill test tests/pm-execution/create-prd.yaml --no-open
+          evalview skill test tests/pm-execution/user-stories.yaml --no-open
+          evalview skill test tests/pm-execution/test-scenarios.yaml --no-open
+
+      - name: Run behavior tests — pm-product-discovery
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          evalview skill test tests/pm-product-discovery/brainstorm-ideas-new.yaml --no-open
+
+      - name: Run behavior tests — pm-product-strategy
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          evalview skill test tests/pm-product-strategy/product-vision.yaml --no-open

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,80 @@
+# Skill Behavior Tests
+
+Structural validation (`validate_plugins.py`) confirms a skill is *well-formed*.
+Behavior tests confirm it *works correctly* — that Claude actually produces the
+right output when the skill is active.
+
+This directory contains behavior test suites for the core skills in the
+marketplace, powered by [EvalView](https://github.com/hidai25/eval-view).
+
+## How It Works
+
+Each `.yaml` file targets a single skill. EvalView loads the `SKILL.md`,
+sends each test's `input` to Claude with the skill context active, and checks
+whether the response contains or avoids the expected phrases.
+
+```
+tests/
+├── pm-toolkit/
+│   └── grammar-check.yaml
+├── pm-execution/
+│   ├── create-prd.yaml
+│   ├── user-stories.yaml
+│   └── test-scenarios.yaml
+├── pm-product-discovery/
+│   └── brainstorm-ideas-new.yaml
+└── pm-product-strategy/
+    └── product-vision.yaml
+```
+
+## Running Locally
+
+```bash
+# Install EvalView
+pip install "evalview>=0.4.0"
+
+# Run a single skill's tests
+evalview skill test tests/pm-execution/create-prd.yaml
+
+# Run all tests
+for f in tests/**/*.yaml; do evalview skill test "$f"; done
+```
+
+You need an `ANTHROPIC_API_KEY` in your environment (or a `.env.local` file).
+
+## CI
+
+The `.github/workflows/skill-behavior-tests.yml` workflow runs automatically
+when a skill file or test file changes. Add `ANTHROPIC_API_KEY` to your
+repository secrets to enable it.
+
+## Writing Tests for a New Skill
+
+Copy this template into `tests/<plugin-name>/<skill-name>.yaml`:
+
+```yaml
+name: <skill-name>-tests
+description: Behavior tests for the <skill-name> skill.
+
+skill: ../../<plugin-name>/skills/<skill-name>/SKILL.md
+model: claude-sonnet-4-5-20251001
+min_pass_rate: 0.8
+
+tests:
+  - name: descriptive-test-name
+    description: One sentence describing what behavior is being verified.
+    input: |
+      A realistic prompt a PM would send to this skill.
+    expected:
+      output_contains:
+        - "key phrase the skill should produce"
+      output_not_contains:
+        - "phrase the skill should never produce"
+```
+
+**Test writing tips:**
+
+- Test *behavior*, not wording. Use phrases that any correct response would include, not exact sentences.
+- Cover the happy path AND at least one edge case or failure mode per skill.
+- `output_not_contains` is as important as `output_contains` — it guards against hallucinations and generic responses.
+- Keep `min_pass_rate` at `0.8` to account for LLM non-determinism.

--- a/tests/pm-execution/create-prd.yaml
+++ b/tests/pm-execution/create-prd.yaml
@@ -1,0 +1,84 @@
+name: create-prd-tests
+description: Behavior tests for the create-prd skill — verifies it produces all 8 required PRD sections with substance, not just headings.
+
+skill: ../../pm-execution/skills/create-prd/SKILL.md
+model: claude-sonnet-4-5-20251001
+min_pass_rate: 0.8
+
+tests:
+  - name: produces-all-eight-sections
+    description: PRD must contain all 8 required sections from the template
+    input: |
+      Build a feature that lets e-commerce shoppers save items to a wishlist and share it with friends.
+    expected:
+      output_contains:
+        - "Summary"
+        - "Background"
+        - "Objective"
+        - "Market Segment"
+        - "Value Proposition"
+        - "Solution"
+        - "Release"
+      output_not_contains:
+        - "I cannot"
+        - "need more information"
+
+  - name: includes-measurable-key-results
+    description: Objective section must contain measurable KRs, not vague goals
+    input: |
+      Add push notification support to a B2B SaaS project management app to increase daily active usage.
+    expected:
+      output_contains:
+        - "%"
+      output_not_contains:
+        - "improve engagement"
+        - "increase usage"
+
+  - name: flags-assumptions-explicitly
+    description: Solution section must call out assumptions clearly
+    input: |
+      Build an AI-powered onboarding flow that personalizes the setup experience based on user role.
+    expected:
+      output_contains:
+        - "ssumption"
+      output_not_contains:
+        - "guaranteed"
+        - "will definitely"
+
+  - name: targets-specific-market-segment
+    description: Market segment must define a specific group, not "all users"
+    input: |
+      Create a bulk import feature for a CRM that lets sales teams upload contacts from CSV files.
+    expected:
+      output_contains:
+        - "sales"
+      output_not_contains:
+        - "all users"
+        - "everyone"
+        - "general public"
+
+  - name: release-section-avoids-hard-dates
+    description: Release planning should use relative timeframes per skill instructions
+    input: |
+      Add two-factor authentication to a consumer fintech app.
+    expected:
+      output_contains:
+        - "Release"
+      output_not_contains:
+        - "January"
+        - "February"
+        - "March"
+        - "Q1 2025"
+        - "Q2 2025"
+
+  - name: uses-plain-language
+    description: PRD should be written for broad readability, avoiding heavy jargon
+    input: |
+      Build a feature that lets restaurant owners create and manage their digital menus.
+    expected:
+      output_contains:
+        - "restaurant"
+      output_not_contains:
+        - "synergize"
+        - "leverage our core competencies"
+        - "paradigm shift"

--- a/tests/pm-execution/test-scenarios.yaml
+++ b/tests/pm-execution/test-scenarios.yaml
@@ -1,0 +1,81 @@
+name: test-scenarios-tests
+description: Behavior tests for the test-scenarios skill — verifies it produces executable QA scenarios with objectives, starting conditions, step-by-step actions, and expected outcomes.
+
+skill: ../../pm-execution/skills/test-scenarios/SKILL.md
+model: claude-sonnet-4-5-20251001
+min_pass_rate: 0.8
+
+tests:
+  - name: includes-all-required-scenario-components
+    description: Every scenario must have objective, conditions, steps, and expected outcomes
+    input: |
+      Product: Mobile banking app
+      User story: As a customer, I want to transfer money to another account so that I can pay people without visiting a branch.
+      Acceptance criteria: Transfer completes within 30 seconds. User receives confirmation. Insufficient balance shows an error.
+      Context: iOS and Android, registered users only
+    expected:
+      output_contains:
+        - "Objective"
+        - "Starting Condition"
+        - "Expected Outcome"
+      output_not_contains:
+        - "I cannot generate"
+        - "need more information"
+
+  - name: covers-happy-path-and-edge-cases
+    description: Should produce both a success scenario and at least one failure/edge case
+    input: |
+      Product: SaaS project management tool
+      User story: As a project manager, I want to invite teammates by email so that they can join my workspace.
+      Acceptance criteria: Valid email triggers invite. Invalid email shows inline error. Already-member email shows warning. Invite expires in 7 days.
+      Context: Web app, admin role only
+    expected:
+      output_contains:
+        - "invalid"
+      output_not_contains:
+        - "happy path only"
+        - "no edge cases"
+
+  - name: steps-are-numbered-and-sequential
+    description: Test steps must be numbered and describe a discrete user action per step
+    input: |
+      Product: E-learning platform
+      User story: As a student, I want to resume a video where I left off so that I don't lose my progress.
+      Acceptance criteria: Progress is saved every 10 seconds. Reopening the video starts from the last saved position.
+      Context: Desktop web, authenticated users
+    expected:
+      output_contains:
+        - "1."
+        - "2."
+      output_not_contains:
+        - "click around"
+        - "do stuff"
+
+  - name: expected-outcomes-are-observable
+    description: Expected outcomes must describe what the user or system visibly does — not internal states
+    input: |
+      Product: Food delivery app
+      User story: As a customer, I want to track my order in real time so that I know when to expect delivery.
+      Acceptance criteria: Map shows driver location. ETA updates every 60 seconds. Notification fires when driver is 2 minutes away.
+      Context: Native mobile app
+    expected:
+      output_contains:
+        - "displays"
+      output_not_contains:
+        - "internally"
+        - "database"
+        - "backend"
+
+  - name: identifies-user-role-performing-test
+    description: Each scenario must specify which user role performs the test actions
+    input: |
+      Product: HR management system
+      User story: As an HR manager, I want to export employee records to CSV so that I can share data with payroll.
+      Acceptance criteria: Export includes all active employees. File downloads with today's date in the filename.
+      Context: Web app, HR manager role
+    expected:
+      output_contains:
+        - "HR"
+      output_not_contains:
+        - "any user"
+        - "someone"

--- a/tests/pm-execution/user-stories.yaml
+++ b/tests/pm-execution/user-stories.yaml
@@ -1,0 +1,81 @@
+name: user-stories-tests
+description: Behavior tests for the user-stories skill — verifies it generates properly structured stories following the 3 C's and INVEST criteria.
+
+skill: ../../pm-execution/skills/user-stories/SKILL.md
+model: claude-sonnet-4-5-20251001
+min_pass_rate: 0.8
+
+tests:
+  - name: uses-as-a-i-want-so-that-format
+    description: Every story must follow the canonical user story format
+    input: |
+      Product: Fitness tracking app
+      Feature: Allow users to log their daily water intake and get hydration reminders
+      Design: N/A
+      Assumptions: Users have previously set up a profile with their weight
+    expected:
+      output_contains:
+        - "As a"
+        - "I want"
+        - "so that"
+      output_not_contains:
+        - "The user should"
+        - "The system shall"
+
+  - name: includes-acceptance-criteria
+    description: Each story must have explicit, testable acceptance criteria
+    input: |
+      Product: B2B invoicing tool
+      Feature: Let finance teams export invoices as PDF with custom branding
+      Design: N/A
+      Assumptions: Company logo and color settings are already configured
+    expected:
+      output_contains:
+        - "Acceptance Criteria"
+      output_not_contains:
+        - "TBD"
+        - "to be defined"
+
+  - name: generates-multiple-independent-stories
+    description: Complex features should be broken into multiple independent stories
+    input: |
+      Product: Online learning platform
+      Feature: Build a complete quiz system with creation, taking, and result tracking
+      Design: N/A
+      Assumptions: Instructors and students are separate user roles
+    expected:
+      output_contains:
+        - "As a"
+      output_not_contains:
+        - "single story"
+        - "one story"
+
+  - name: identifies-correct-user-role
+    description: Stories must identify a specific user role, not a generic "user"
+    input: |
+      Product: Hospital scheduling system
+      Feature: Let doctors block time slots on their calendar for administrative work
+      Design: N/A
+      Assumptions: The system has both doctor and patient roles
+    expected:
+      output_contains:
+        - "doctor"
+      output_not_contains:
+        - "As a user"
+        - "As a person"
+
+  - name: acceptance-criteria-are-testable
+    description: Acceptance criteria must be concrete and verifiable, not vague
+    input: |
+      Product: E-commerce checkout
+      Feature: Add an order summary sidebar that stays visible during the checkout flow
+      Design: N/A
+      Assumptions: Checkout is a multi-step form
+    expected:
+      output_contains:
+        - "displayed"
+      output_not_contains:
+        - "user-friendly"
+        - "intuitive"
+        - "easy to use"
+        - "seamless"

--- a/tests/pm-product-discovery/brainstorm-ideas-new.yaml
+++ b/tests/pm-product-discovery/brainstorm-ideas-new.yaml
@@ -1,0 +1,70 @@
+name: brainstorm-ideas-new-tests
+description: Behavior tests for the brainstorm-ideas-new skill — verifies it generates ideas from PM, Designer, and Engineer perspectives with prioritization and assumption identification.
+
+skill: ../../pm-product-discovery/skills/brainstorm-ideas-new/SKILL.md
+model: claude-sonnet-4-5-20251001
+min_pass_rate: 0.8
+
+tests:
+  - name: produces-three-distinct-perspectives
+    description: Output must cover PM, Designer, and Engineer viewpoints explicitly
+    input: |
+      A mobile app that helps pet owners track their pet's health, vet appointments, and medications.
+    expected:
+      output_contains:
+        - "PM"
+        - "Designer"
+        - "Engineer"
+      output_not_contains:
+        - "I cannot"
+        - "insufficient information"
+
+  - name: generates-at-least-five-ideas-per-perspective
+    description: Each perspective should yield at least 5 distinct feature ideas
+    input: |
+      A B2B SaaS tool for freelancers to manage client contracts, invoices, and project timelines.
+    expected:
+      output_contains:
+        - "1."
+        - "2."
+        - "3."
+        - "4."
+        - "5."
+      output_not_contains:
+        - "only one idea"
+        - "just a few ideas"
+
+  - name: prioritizes-top-five-across-perspectives
+    description: Must select and rank the top 5 ideas across all perspectives
+    input: |
+      A consumer app that helps people reduce food waste by tracking what's in their fridge and suggesting recipes.
+    expected:
+      output_contains:
+        - "top"
+      output_not_contains:
+        - "cannot prioritize"
+        - "all ideas are equal"
+
+  - name: identifies-key-assumptions-for-prioritized-ideas
+    description: Each top idea must include at least one assumption to validate
+    input: |
+      An AI-powered tool for small business owners to automate their social media content calendar.
+    expected:
+      output_contains:
+        - "ssumption"
+      output_not_contains:
+        - "no assumptions"
+        - "proven"
+        - "guaranteed"
+
+  - name: focuses-on-initial-discovery-not-iterations
+    description: Ideas should address core value validation, not incremental improvements
+    input: |
+      A new app that connects local farmers directly with consumers for fresh produce delivery.
+    expected:
+      output_contains:
+        - "core"
+      output_not_contains:
+        - "version 2"
+        - "future iteration"
+        - "next phase"

--- a/tests/pm-product-strategy/product-vision.yaml
+++ b/tests/pm-product-strategy/product-vision.yaml
@@ -1,0 +1,62 @@
+name: product-vision-tests
+description: Behavior tests for the product-vision skill — verifies it generates inspiring, achievable, emotionally resonant vision statements with multiple options and clear rationale.
+
+skill: ../../pm-product-strategy/skills/product-vision/SKILL.md
+model: claude-sonnet-4-5-20251001
+min_pass_rate: 0.8
+
+tests:
+  - name: produces-multiple-vision-options
+    description: Should generate 3-5 distinct vision statement variations, not a single answer
+    input: |
+      Company: A startup building AI-powered tools for independent therapists to reduce admin work and focus on patient care.
+    expected:
+      output_contains:
+        - "1."
+        - "2."
+        - "3."
+      output_not_contains:
+        - "here is your vision"
+        - "the vision is"
+
+  - name: vision-is-concise-and-memorable
+    description: Vision statements should be communicable in one sentence, not a paragraph
+    input: |
+      Company: A fintech startup helping first-generation immigrants send money home with zero fees and instant delivery.
+    expected:
+      output_not_contains:
+        - "In order to achieve our long-term goal of"
+        - "Through leveraging our core competencies"
+
+  - name: selects-strongest-option-with-rationale
+    description: Must recommend one vision and explain why it was chosen
+    input: |
+      Company: An edtech platform that teaches coding to children aged 8-14 through story-driven games.
+    expected:
+      output_contains:
+        - "rationale"
+      output_not_contains:
+        - "all options are equally good"
+        - "you decide"
+
+  - name: vision-addresses-customer-not-just-company
+    description: Vision must be customer-centric, not purely about the business
+    input: |
+      Company: A SaaS platform that helps e-commerce brands manage returns and reduce reverse logistics costs.
+    expected:
+      output_not_contains:
+        - "maximize shareholder value"
+        - "achieve market dominance"
+        - "become the largest"
+
+  - name: avoids-jargon-and-buzzwords
+    description: Vision language must be clear and emotionally resonant — not corporate buzzwords
+    input: |
+      Company: A mental wellness app for remote workers experiencing isolation and burnout.
+    expected:
+      output_not_contains:
+        - "synergy"
+        - "leverage"
+        - "disrupt"
+        - "paradigm"
+        - "ecosystem"

--- a/tests/pm-toolkit/grammar-check.yaml
+++ b/tests/pm-toolkit/grammar-check.yaml
@@ -1,0 +1,79 @@
+name: grammar-check-tests
+description: Behavior tests for the grammar-check skill — verifies it identifies errors and suggests fixes without rewriting the full text.
+
+skill: ../../pm-toolkit/skills/grammar-check/SKILL.md
+model: claude-sonnet-4-5-20251001
+min_pass_rate: 0.8
+
+tests:
+  - name: detects-subject-verb-disagreement
+    description: Should flag "The team are" as a subject-verb agreement error
+    input: |
+      Objective: Professional business email
+      Text: The team are working hard on the new feature. Each engineers have submitted their update.
+    expected:
+      output_contains:
+        - "agreement"
+      output_not_contains:
+        - "looks good"
+        - "no errors"
+        - "well written"
+
+  - name: flags-tense-inconsistency
+    description: Should catch mixed past and present tense in the same passage
+    input: |
+      Objective: Product launch announcement
+      Text: We launched the feature last Monday. Users can now access it and the team worked for six months to build it. Tomorrow we will have shipped three updates.
+    expected:
+      output_contains:
+        - "tense"
+      output_not_contains:
+        - "no issues"
+        - "correct"
+
+  - name: identifies-logical-contradiction
+    description: Should detect contradictory claims within the same paragraph
+    input: |
+      Objective: Investor update
+      Text: Our churn rate is our biggest strength. We retained 95% of customers last quarter while simultaneously losing the majority of our user base due to pricing changes.
+    expected:
+      output_contains:
+        - "contradict"
+      output_not_contains:
+        - "logically sound"
+        - "no issues"
+
+  - name: catches-vague-pronoun-reference
+    description: Should flag ambiguous pronoun references
+    input: |
+      Objective: Internal engineering handoff doc
+      Text: Sarah told Maria that she would own the migration. It needs to be done before it goes live, but it hasn't been scheduled yet.
+    expected:
+      output_contains:
+        - "unclear"
+      output_not_contains:
+        - "clear"
+        - "well written"
+
+  - name: suggests-fix-not-full-rewrite
+    description: Should give targeted suggestions, not rewrite the whole text
+    input: |
+      Objective: Marketing blog post
+      Text: Our product is very unique and totally revolutionary. Customers loves the interface and say its the best.
+    expected:
+      output_contains:
+        - "unique"
+      output_not_contains:
+        - "Here is the rewritten"
+        - "Here is the corrected version"
+        - "Rewritten text"
+
+  - name: clean-text-passes-gracefully
+    description: Should acknowledge when text has no significant issues
+    input: |
+      Objective: Internal team memo
+      Text: The sprint review is scheduled for Friday at 2 PM. Please bring your demo ready and review the acceptance criteria beforehand.
+    expected:
+      output_not_contains:
+        - "critical error"
+        - "major issue"


### PR DESCRIPTION
## What this adds

`validate_plugins.py` already does an excellent job confirming every skill is well-formed — correct frontmatter, valid cross-references, README sections in place.

This PR adds the next layer: **behavior tests that actually run each skill against Claude** and verify the output is correct. A skill can be structurally valid but still produce the wrong artifacts. These tests catch that.

32 tests across 8 skills in 4 plugins:

| Plugin | Skill | Tests |
|---|---|---|
| pm-toolkit | grammar-check | 6 |
| pm-execution | create-prd | 6 |
| pm-execution | user-stories | 5 |
| pm-execution | test-scenarios | 5 |
| pm-product-discovery | brainstorm-ideas-new | 5 |
| pm-product-strategy | product-vision | 5 |

Each test checks that the skill output **contains** the key phrases a PM would expect (e.g. `create-prd` must output all 8 sections, use relative timeframes in Release, flag assumptions explicitly) and **does not contain** anti-patterns (jargon, vague goals, full rewrites when targeted fixes were requested).

## Why this matters as the marketplace grows

With 267 forks and contributors adding skills, a skill that worked six months ago could quietly degrade when its `SKILL.md` gets edited. Structural validation won't catch it. Behavior tests will.

## How to enable in CI

Add `ANTHROPIC_API_KEY` to your repository secrets. The workflow triggers automatically whenever a skill file or test file changes.

## Running locally

```bash
pip install "evalview>=0.4.0"
evalview skill test tests/pm-execution/create-prd.yaml
```

## Adding tests for new skills

`tests/README.md` includes a template. The format is intentionally simple — each test is a realistic PM prompt and a set of expected/forbidden phrases. No Python required.

---

I built [EvalView](https://github.com/hidai25/eval-view) — an open-source end-to-end testing framework for AI agents and skills. This PR uses EvalView as the test runner. Happy to help write tests for the remaining plugins if this direction makes sense to you.