### PR TITLE
docs: add OpenCode to Other AI assistants table

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,19 @@ The `skills/*/SKILL.md` files follow the universal skill format and work with an
 | Tool | How to use | What works |
 |------|-----------|------------|
 | **Gemini CLI** | Copy skill folders to `.gemini/skills/` | Skills only |
+| **OpenCode** | Copy skill folders to `.opencode/skills/` | Skills only |
 | **Cursor** | Copy skill folders to `.cursor/skills/` | Skills only |
 | **Codex CLI** | Copy skill folders to `.codex/skills/` | Skills only |
 | **Kiro** | Copy skill folders to `.kiro/skills/` | Skills only |
 
 ```bash
-# Example: copy all skills for Gemini CLI
+# Example: copy all skills for OpenCode (project-level)
+for plugin in pm-*/; do
+  mkdir -p .opencode/skills/
+  cp -r "$plugin/skills/"* .opencode/skills/ 2>/dev/null
+done
+
+# Example: copy all skills for Gemini CLI (global)
 for plugin in pm-*/; do
   cp -r "$plugin/skills/"* ~/.gemini/skills/ 2>/dev/null
 done


### PR DESCRIPTION
## Summary
- Added **OpenCode** to the *Other AI assistants (skills only)* table in `README.md`.
- Updated the bash script example to include a project-level integration for OpenCode.
- Verified that proejct skills are fully compatible with OpenCode skill tool.