### PR TITLE
Add Claude session start hook configuration

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Python 3 is pre-installed and validate_plugins.py uses only stdlib.
+# Ensure python3 is available on PATH.
+command -v python3 >/dev/null 2>&1 || { echo "python3 not found"; exit 1; }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a session start hook configuration for Claude Code on the web, including a validation script that ensures Python 3 is available in the environment.

## Key Changes
- Added `.claude/settings.json` with a `SessionStart` hook configuration that triggers a bash script when a session begins
- Added `.claude/hooks/session-start.sh` that:
  - Only executes in Claude Code on the web (checks `CLAUDE_CODE_REMOTE` environment variable)
  - Validates that `python3` is available on the system PATH
  - Exits gracefully if not running in the web environment

## Implementation Details
The hook script uses strict bash settings (`set -euo pipefail`) for safety and performs a simple command availability check using `command -v` rather than relying on `which`, making it more portable across different shell environments.

https://claude.ai/code/session_01Dj18XJS2RM62fWTZaRHcBL