### PR TITLE
Add .claude/commands and .claude/skills for native Claude Code integr…

### DIFF
--- a/.claude/commands/analyze-cohorts.md
+++ b/.claude/commands/analyze-cohorts.md
@@ -1,0 +1,1 @@
+../../pm-data-analytics/commands/analyze-cohorts.md

--- a/.claude/commands/analyze-feedback.md
+++ b/.claude/commands/analyze-feedback.md
@@ -1,0 +1,1 @@
+../../pm-market-research/commands/analyze-feedback.md

--- a/.claude/commands/analyze-test.md
+++ b/.claude/commands/analyze-test.md
@@ -1,0 +1,1 @@
+../../pm-data-analytics/commands/analyze-test.md

--- a/.claude/commands/battlecard.md
+++ b/.claude/commands/battlecard.md
@@ -1,0 +1,1 @@
+../../pm-go-to-market/commands/battlecard.md

--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -1,0 +1,1 @@
+../../pm-product-discovery/commands/brainstorm.md

--- a/.claude/commands/business-model.md
+++ b/.claude/commands/business-model.md
@@ -1,0 +1,1 @@
+../../pm-product-strategy/commands/business-model.md

--- a/.claude/commands/competitive-analysis.md
+++ b/.claude/commands/competitive-analysis.md
@@ -1,0 +1,1 @@
+../../pm-market-research/commands/competitive-analysis.md

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,0 +1,1 @@
+../../pm-product-discovery/commands/discover.md

--- a/.claude/commands/draft-nda.md
+++ b/.claude/commands/draft-nda.md
@@ -1,0 +1,1 @@
+../../pm-toolkit/commands/draft-nda.md

--- a/.claude/commands/generate-data.md
+++ b/.claude/commands/generate-data.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/generate-data.md

--- a/.claude/commands/growth-strategy.md
+++ b/.claude/commands/growth-strategy.md
@@ -1,0 +1,1 @@
+../../pm-go-to-market/commands/growth-strategy.md

--- a/.claude/commands/interview.md
+++ b/.claude/commands/interview.md
@@ -1,0 +1,1 @@
+../../pm-product-discovery/commands/interview.md

--- a/.claude/commands/market-product.md
+++ b/.claude/commands/market-product.md
@@ -1,0 +1,1 @@
+../../pm-marketing-growth/commands/market-product.md

--- a/.claude/commands/market-scan.md
+++ b/.claude/commands/market-scan.md
@@ -1,0 +1,1 @@
+../../pm-product-strategy/commands/market-scan.md

--- a/.claude/commands/meeting-notes.md
+++ b/.claude/commands/meeting-notes.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/meeting-notes.md

--- a/.claude/commands/north-star.md
+++ b/.claude/commands/north-star.md
@@ -1,0 +1,1 @@
+../../pm-marketing-growth/commands/north-star.md

--- a/.claude/commands/plan-launch.md
+++ b/.claude/commands/plan-launch.md
@@ -1,0 +1,1 @@
+../../pm-go-to-market/commands/plan-launch.md

--- a/.claude/commands/plan-okrs.md
+++ b/.claude/commands/plan-okrs.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/plan-okrs.md

--- a/.claude/commands/pre-mortem.md
+++ b/.claude/commands/pre-mortem.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/pre-mortem.md

--- a/.claude/commands/pricing.md
+++ b/.claude/commands/pricing.md
@@ -1,0 +1,1 @@
+../../pm-product-strategy/commands/pricing.md

--- a/.claude/commands/privacy-policy.md
+++ b/.claude/commands/privacy-policy.md
@@ -1,0 +1,1 @@
+../../pm-toolkit/commands/privacy-policy.md

--- a/.claude/commands/proofread.md
+++ b/.claude/commands/proofread.md
@@ -1,0 +1,1 @@
+../../pm-toolkit/commands/proofread.md

--- a/.claude/commands/research-users.md
+++ b/.claude/commands/research-users.md
@@ -1,0 +1,1 @@
+../../pm-market-research/commands/research-users.md

--- a/.claude/commands/review-resume.md
+++ b/.claude/commands/review-resume.md
@@ -1,0 +1,1 @@
+../../pm-toolkit/commands/review-resume.md

--- a/.claude/commands/setup-metrics.md
+++ b/.claude/commands/setup-metrics.md
@@ -1,0 +1,1 @@
+../../pm-product-discovery/commands/setup-metrics.md

--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/sprint.md

--- a/.claude/commands/stakeholder-map.md
+++ b/.claude/commands/stakeholder-map.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/stakeholder-map.md

--- a/.claude/commands/strategy.md
+++ b/.claude/commands/strategy.md
@@ -1,0 +1,1 @@
+../../pm-product-strategy/commands/strategy.md

--- a/.claude/commands/tailor-resume.md
+++ b/.claude/commands/tailor-resume.md
@@ -1,0 +1,1 @@
+../../pm-toolkit/commands/tailor-resume.md

--- a/.claude/commands/test-scenarios.md
+++ b/.claude/commands/test-scenarios.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/test-scenarios.md

--- a/.claude/commands/transform-roadmap.md
+++ b/.claude/commands/transform-roadmap.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/transform-roadmap.md

--- a/.claude/commands/triage-requests.md
+++ b/.claude/commands/triage-requests.md
@@ -1,0 +1,1 @@
+../../pm-product-discovery/commands/triage-requests.md

--- a/.claude/commands/value-proposition.md
+++ b/.claude/commands/value-proposition.md
@@ -1,0 +1,1 @@
+../../pm-product-strategy/commands/value-proposition.md

--- a/.claude/commands/write-prd.md
+++ b/.claude/commands/write-prd.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/write-prd.md

--- a/.claude/commands/write-query.md
+++ b/.claude/commands/write-query.md
@@ -1,0 +1,1 @@
+../../pm-data-analytics/commands/write-query.md

--- a/.claude/commands/write-stories.md
+++ b/.claude/commands/write-stories.md
@@ -1,0 +1,1 @@
+../../pm-execution/commands/write-stories.md

--- a/.claude/skills/ab-test-analysis/SKILL.md
+++ b/.claude/skills/ab-test-analysis/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-data-analytics/skills/ab-test-analysis/SKILL.md

--- a/.claude/skills/analyze-feature-requests/SKILL.md
+++ b/.claude/skills/analyze-feature-requests/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/analyze-feature-requests/SKILL.md

--- a/.claude/skills/ansoff-matrix/SKILL.md
+++ b/.claude/skills/ansoff-matrix/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/ansoff-matrix/SKILL.md

--- a/.claude/skills/beachhead-segment/SKILL.md
+++ b/.claude/skills/beachhead-segment/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-go-to-market/skills/beachhead-segment/SKILL.md

--- a/.claude/skills/brainstorm-experiments-existing/SKILL.md
+++ b/.claude/skills/brainstorm-experiments-existing/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/brainstorm-experiments-existing/SKILL.md

--- a/.claude/skills/brainstorm-experiments-new/SKILL.md
+++ b/.claude/skills/brainstorm-experiments-new/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/brainstorm-experiments-new/SKILL.md

--- a/.claude/skills/brainstorm-ideas-existing/SKILL.md
+++ b/.claude/skills/brainstorm-ideas-existing/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/brainstorm-ideas-existing/SKILL.md

--- a/.claude/skills/brainstorm-ideas-new/SKILL.md
+++ b/.claude/skills/brainstorm-ideas-new/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/brainstorm-ideas-new/SKILL.md

--- a/.claude/skills/brainstorm-okrs/SKILL.md
+++ b/.claude/skills/brainstorm-okrs/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/brainstorm-okrs/SKILL.md

--- a/.claude/skills/business-model/SKILL.md
+++ b/.claude/skills/business-model/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/business-model/SKILL.md

--- a/.claude/skills/cohort-analysis/SKILL.md
+++ b/.claude/skills/cohort-analysis/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-data-analytics/skills/cohort-analysis/SKILL.md

--- a/.claude/skills/competitive-battlecard/SKILL.md
+++ b/.claude/skills/competitive-battlecard/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-go-to-market/skills/competitive-battlecard/SKILL.md

--- a/.claude/skills/competitor-analysis/SKILL.md
+++ b/.claude/skills/competitor-analysis/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-market-research/skills/competitor-analysis/SKILL.md

--- a/.claude/skills/create-prd/SKILL.md
+++ b/.claude/skills/create-prd/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/create-prd/SKILL.md

--- a/.claude/skills/customer-journey-map/SKILL.md
+++ b/.claude/skills/customer-journey-map/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-market-research/skills/customer-journey-map/SKILL.md

--- a/.claude/skills/draft-nda/SKILL.md
+++ b/.claude/skills/draft-nda/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-toolkit/skills/draft-nda/SKILL.md

--- a/.claude/skills/dummy-dataset/SKILL.md
+++ b/.claude/skills/dummy-dataset/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/dummy-dataset/SKILL.md

--- a/.claude/skills/grammar-check/SKILL.md
+++ b/.claude/skills/grammar-check/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-toolkit/skills/grammar-check/SKILL.md

--- a/.claude/skills/growth-loops/SKILL.md
+++ b/.claude/skills/growth-loops/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-go-to-market/skills/growth-loops/SKILL.md

--- a/.claude/skills/gtm-motions/SKILL.md
+++ b/.claude/skills/gtm-motions/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-go-to-market/skills/gtm-motions/SKILL.md

--- a/.claude/skills/gtm-strategy/SKILL.md
+++ b/.claude/skills/gtm-strategy/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-go-to-market/skills/gtm-strategy/SKILL.md

--- a/.claude/skills/ideal-customer-profile/SKILL.md
+++ b/.claude/skills/ideal-customer-profile/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-go-to-market/skills/ideal-customer-profile/SKILL.md

--- a/.claude/skills/identify-assumptions-existing/SKILL.md
+++ b/.claude/skills/identify-assumptions-existing/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/identify-assumptions-existing/SKILL.md

--- a/.claude/skills/identify-assumptions-new/SKILL.md
+++ b/.claude/skills/identify-assumptions-new/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/identify-assumptions-new/SKILL.md

--- a/.claude/skills/interview-script/SKILL.md
+++ b/.claude/skills/interview-script/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/interview-script/SKILL.md

--- a/.claude/skills/job-stories/SKILL.md
+++ b/.claude/skills/job-stories/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/job-stories/SKILL.md

--- a/.claude/skills/lean-canvas/SKILL.md
+++ b/.claude/skills/lean-canvas/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/lean-canvas/SKILL.md

--- a/.claude/skills/market-segments/SKILL.md
+++ b/.claude/skills/market-segments/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-market-research/skills/market-segments/SKILL.md

--- a/.claude/skills/market-sizing/SKILL.md
+++ b/.claude/skills/market-sizing/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-market-research/skills/market-sizing/SKILL.md

--- a/.claude/skills/marketing-ideas/SKILL.md
+++ b/.claude/skills/marketing-ideas/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-marketing-growth/skills/marketing-ideas/SKILL.md

--- a/.claude/skills/metrics-dashboard/SKILL.md
+++ b/.claude/skills/metrics-dashboard/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/metrics-dashboard/SKILL.md

--- a/.claude/skills/monetization-strategy/SKILL.md
+++ b/.claude/skills/monetization-strategy/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/monetization-strategy/SKILL.md

--- a/.claude/skills/north-star-metric/SKILL.md
+++ b/.claude/skills/north-star-metric/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-marketing-growth/skills/north-star-metric/SKILL.md

--- a/.claude/skills/opportunity-solution-tree/SKILL.md
+++ b/.claude/skills/opportunity-solution-tree/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/opportunity-solution-tree/SKILL.md

--- a/.claude/skills/outcome-roadmap/SKILL.md
+++ b/.claude/skills/outcome-roadmap/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/outcome-roadmap/SKILL.md

--- a/.claude/skills/pestle-analysis/SKILL.md
+++ b/.claude/skills/pestle-analysis/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/pestle-analysis/SKILL.md

--- a/.claude/skills/porters-five-forces/SKILL.md
+++ b/.claude/skills/porters-five-forces/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/porters-five-forces/SKILL.md

--- a/.claude/skills/positioning-ideas/SKILL.md
+++ b/.claude/skills/positioning-ideas/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-marketing-growth/skills/positioning-ideas/SKILL.md

--- a/.claude/skills/pre-mortem/SKILL.md
+++ b/.claude/skills/pre-mortem/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/pre-mortem/SKILL.md

--- a/.claude/skills/pricing-strategy/SKILL.md
+++ b/.claude/skills/pricing-strategy/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/pricing-strategy/SKILL.md

--- a/.claude/skills/prioritization-frameworks/SKILL.md
+++ b/.claude/skills/prioritization-frameworks/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/prioritization-frameworks/SKILL.md

--- a/.claude/skills/prioritize-assumptions/SKILL.md
+++ b/.claude/skills/prioritize-assumptions/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/prioritize-assumptions/SKILL.md

--- a/.claude/skills/prioritize-features/SKILL.md
+++ b/.claude/skills/prioritize-features/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/prioritize-features/SKILL.md

--- a/.claude/skills/privacy-policy/SKILL.md
+++ b/.claude/skills/privacy-policy/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-toolkit/skills/privacy-policy/SKILL.md

--- a/.claude/skills/product-name/SKILL.md
+++ b/.claude/skills/product-name/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-marketing-growth/skills/product-name/SKILL.md

--- a/.claude/skills/product-strategy/SKILL.md
+++ b/.claude/skills/product-strategy/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/product-strategy/SKILL.md

--- a/.claude/skills/product-vision/SKILL.md
+++ b/.claude/skills/product-vision/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/product-vision/SKILL.md

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/release-notes/SKILL.md

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/retro/SKILL.md

--- a/.claude/skills/review-resume/SKILL.md
+++ b/.claude/skills/review-resume/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-toolkit/skills/review-resume/SKILL.md

--- a/.claude/skills/sentiment-analysis/SKILL.md
+++ b/.claude/skills/sentiment-analysis/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-market-research/skills/sentiment-analysis/SKILL.md

--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/sprint-plan/SKILL.md

--- a/.claude/skills/sql-queries/SKILL.md
+++ b/.claude/skills/sql-queries/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-data-analytics/skills/sql-queries/SKILL.md

--- a/.claude/skills/stakeholder-map/SKILL.md
+++ b/.claude/skills/stakeholder-map/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/stakeholder-map/SKILL.md

--- a/.claude/skills/startup-canvas/SKILL.md
+++ b/.claude/skills/startup-canvas/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/startup-canvas/SKILL.md

--- a/.claude/skills/summarize-interview/SKILL.md
+++ b/.claude/skills/summarize-interview/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-discovery/skills/summarize-interview/SKILL.md

--- a/.claude/skills/summarize-meeting/SKILL.md
+++ b/.claude/skills/summarize-meeting/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/summarize-meeting/SKILL.md

--- a/.claude/skills/swot-analysis/SKILL.md
+++ b/.claude/skills/swot-analysis/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/swot-analysis/SKILL.md

--- a/.claude/skills/test-scenarios/SKILL.md
+++ b/.claude/skills/test-scenarios/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/test-scenarios/SKILL.md

--- a/.claude/skills/user-personas/SKILL.md
+++ b/.claude/skills/user-personas/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-market-research/skills/user-personas/SKILL.md

--- a/.claude/skills/user-segmentation/SKILL.md
+++ b/.claude/skills/user-segmentation/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-market-research/skills/user-segmentation/SKILL.md

--- a/.claude/skills/user-stories/SKILL.md
+++ b/.claude/skills/user-stories/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/user-stories/SKILL.md

--- a/.claude/skills/value-prop-statements/SKILL.md
+++ b/.claude/skills/value-prop-statements/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-marketing-growth/skills/value-prop-statements/SKILL.md

--- a/.claude/skills/value-proposition/SKILL.md
+++ b/.claude/skills/value-proposition/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-product-strategy/skills/value-proposition/SKILL.md

--- a/.claude/skills/wwas/SKILL.md
+++ b/.claude/skills/wwas/SKILL.md
@@ -1,0 +1,1 @@
+../../../pm-execution/skills/wwas/SKILL.md


### PR DESCRIPTION
…ation

Creates relative symlinks in .claude/commands/ (36 commands) and .claude/skills/ (65 skills) pointing to the existing plugin files, making all PM slash commands and skills available natively in Claude Code without duplicating any content.

https://claude.ai/code/session_01F3gN2zhNGYX8FfZdR7TH1D