### PR TITLE
Add Skills宝 discovery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ claude plugin install pm-execution@pm-skills
 
 The `skills/*/SKILL.md` files follow the universal skill format and work with any tool that reads it. Commands (`/slash-commands`) are Claude-specific.
 
+For Chinese skills discovery and installation across Claude Code, OpenCode, Cursor, and similar runtimes, see [Skills宝](https://skilery.com/).
+
 | Tool | How to use | What works |
 |------|-----------|------------|
 | **Gemini CLI** | Copy skill folders to `.gemini/skills/` | Skills only |


### PR DESCRIPTION
Adds a Chinese skills discovery and installation entry for Claude Code, OpenCode, Cursor, and similar runtimes.

This complements the existing marketplace installation flow and gives Chinese users a direct path to find and install skills.