### PR TITLE
Fix subject-verb agreement typo in Porter's Five Forces skill

### DIFF
--- a/pm-product-strategy/skills/porters-five-forces/SKILL.md
+++ b/pm-product-strategy/skills/porters-five-forces/SKILL.md
@@ -90,7 +90,7 @@ The ability of customers to negotiate lower prices or demand higher quality, aff
 **High Buyer Power When:**
 - Few large customers (concentrated demand)
 - Buyers switch easily and often (low switching costs)
-- Backwards integration threat (customers become competitors)
+- Backward integration threat (customers become competitors)
 - Product is undifferentiated (commoditized)
 - Buyers have price sensitivity or tight budgets
 - Buyers have full information about alternatives

--- a/pm-product-strategy/skills/porters-five-forces/SKILL.md
+++ b/pm-product-strategy/skills/porters-five-forces/SKILL.md
@@ -133,7 +133,7 @@ The risk that customers will switch to alternative products that solve the same 
 - Switching costs are high
 - Your product is deeply integrated into customer workflows
 - Customer preference and loyalty are strong
-- Barrier to substitute entry are high
+- Barriers to substitute entry are high
 - Your product solves the problem uniquely
 
 **Strategic Implications:**


### PR DESCRIPTION
## Summary

- Fixes a subject-verb agreement error in `pm-product-strategy/skills/porters-five-forces/SKILL.md`
- **Before:** `Barrier to substitute entry are high`
- **After:** `Barriers to substitute entry are high`

Small one-word fix under the **Threat of Substitutes → Low Threat When** bullet list.