### PR TITLE
Fix Claude Cowork installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Commands are designed to flow into each other, matching the PM workflow. After a
 
 1. Open **Customize** (bottom-left)
 2. Go to **Browse plugins** → **Personal** → **+**
-3. Select **Add marketplace from GitHub**
+3. Click **Create plugin** → **Add marketplace** → **Add from repository**
 4. Enter: `phuryn/pm-skills`
 
 All 9 plugins install automatically. You get both commands (`/discover`, `/strategy`, etc.) and skills.


### PR DESCRIPTION
## Summary

The Cowork installation instructions in step 3 were missing intermediate UI steps, which would block first-time users (the exact audience this path is labeled "recommended for").

**Before:** `Select Add marketplace from GitHub`
**After:** `Click Create plugin → Add marketplace → Add from repository`

Verified by following the actual Cowork UI flow.