### PR TITLE
Add Seven Powers strategy skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "pm-product-strategy",
-      "description": "Product strategy skills for PMs: vision, strategy canvas, value propositions, lean canvas, business model canvas, SWOT, PESTLE, Ansoff Matrix, Porter's Five Forces, and monetization.",
+      "description": "Product strategy skills for PMs: vision, strategy canvas, value propositions, lean canvas, business model canvas, SWOT, PESTLE, Ansoff Matrix, Porter's Five Forces, Seven Powers, and monetization.",
       "source": "./pm-product-strategy",
       "category": "product-management"
     },

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # PM Skills Marketplace: The AI Operating System for Better Product Decisions
 
-> 68 PM skills and 42 chained workflows across 9 plugins. Claude Code, Cowork, and more. From discovery to strategy, execution, launch, growth, and shipping AI-built code. 
+> 69 PM skills and 42 chained workflows across 9 plugins. Claude Code, Cowork, and more. From discovery to strategy, execution, launch, growth, and shipping AI-built code.
 
 ![PM Skills marketplace: skills, commands, and all 9 plugins at a glance](.docs/images/plugins.png)
 
@@ -178,11 +178,11 @@ Commands:
 </details>
 
 <details>
-<summary><strong>2. pm-product-strategy</strong> — Vision, business models, pricing, competitive landscape (12 skills, 5 commands)</summary>
+<summary><strong>2. pm-product-strategy</strong> — Vision, business models, pricing, competitive landscape (13 skills, 5 commands)</summary>
 
 Product strategy, vision, business models, pricing, and macro environment analysis. Covers the full strategic toolkit from vision crafting through competitive landscape scanning.
 
-**Skills (12):**
+**Skills (13):**
 
 - `product-strategy` — Comprehensive 9-section Product Strategy Canvas (vision → defensibility)
 - `startup-canvas` — Startup Canvas combining Product Strategy (9 sections) + Business Model — an alternative to BMC and Lean Canvas for new products
@@ -195,6 +195,7 @@ Product strategy, vision, business models, pricing, and macro environment analys
 - `swot-analysis` — SWOT analysis with actionable recommendations
 - `pestle-analysis` — Macro environment: Political, Economic, Social, Technological, Legal, Environmental
 - `porters-five-forces` — Competitive forces analysis (rivalry, suppliers, buyers, substitutes, new entrants)
+- `seven-powers` — Durable competitive advantage analysis across scale economies, network effects, counter-positioning, switching costs, branding, cornered resource, and process power
 - `ansoff-matrix` — Growth strategy mapping across markets and products
 
 **Commands (5):**
@@ -211,6 +212,7 @@ Skills:
 - `Compare Lean Canvas vs Business Model Canvas vs Startup Canvas for my marketplace startup`
 - `Design a value proposition for our AI writing assistant targeting non-native English speakers`
 - `Run a Porter's Five Forces analysis for the project management SaaS market`
+- `Assess whether our vertical AI agent has a durable competitive moat`
 
 Commands:
 - `/strategy B2B project management tool for agencies`

--- a/pm-product-strategy/.claude-plugin/plugin.json
+++ b/pm-product-strategy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-product-strategy",
   "version": "2.0.0",
-  "description": "Product strategy skills for PMs: vision, strategy canvas, value propositions, lean canvas, business model canvas, SWOT, PESTLE, Ansoff Matrix, Porter's Five Forces, and monetization.",
+  "description": "Product strategy skills for PMs: vision, strategy canvas, value propositions, lean canvas, business model canvas, SWOT, PESTLE, Ansoff Matrix, Porter's Five Forces, Seven Powers, and monetization.",
   "author": {
     "name": "Paweł Huryn",
     "email": "pawel@productcompass.pm",

--- a/pm-product-strategy/README.md
+++ b/pm-product-strategy/README.md
@@ -1,8 +1,8 @@
 # pm-product-strategy
 
-Product strategy skills for PMs: vision, strategy canvas, startup canvas, value propositions, lean canvas, business model canvas, SWOT, PESTLE, Ansoff Matrix, Porter's Five Forces, pricing, and monetization.
+Product strategy skills for PMs: vision, strategy canvas, startup canvas, value propositions, lean canvas, business model canvas, SWOT, PESTLE, Ansoff Matrix, Porter's Five Forces, Seven Powers, pricing, and monetization.
 
-## Skills (12)
+## Skills (13)
 
 - **ansoff-matrix** — Generate an Ansoff Matrix analysis mapping growth strategies across market penetration, market development, product development, and diversification.
 - **business-model** — Generate a Business Model Canvas with all 9 building blocks.
@@ -13,6 +13,7 @@ Product strategy skills for PMs: vision, strategy canvas, startup canvas, value 
 - **pricing-strategy** — Analyze and design pricing strategies including pricing models, competitive pricing analysis, willingness-to-pay estimation, and price elasticity considerations.
 - **product-strategy** — Generate a comprehensive product strategy using the 9-section Product Strategy Canvas covering vision, segments, costs, value propositions, trade-offs, metrics, growth, capabilities, and defensibility.
 - **product-vision** — Brainstorm an inspiring, achievable, and emotional product vision that motivates teams.
+- **seven-powers** — Assess durable competitive advantage using Hamilton Helmer's 7 Powers framework: scale economies, network effects, counter-positioning, switching costs, branding, cornered resource, and process power.
 - **startup-canvas** — Generate a Startup Canvas combining Product Strategy (9 sections) and Business Model (Cost Structure + Revenue Streams) for a new product. An alternative to Business Model Canvas and Lean Canvas that separates strategy from business model.
 - **swot-analysis** — Perform a detailed SWOT analysis identifying strengths, weaknesses, opportunities, and threats with actionable recommendations.
 - **value-proposition** — Generate a detailed value proposition using a 6-part JTBD template (Who, Why, What before, How, What after, Alternatives).

--- a/pm-product-strategy/skills/seven-powers/SKILL.md
+++ b/pm-product-strategy/skills/seven-powers/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: seven-powers
+description: "Assess durable competitive advantage using Hamilton Helmer's 7 Powers framework — scale economies, network effects, counter-positioning, switching costs, branding, cornered resource, and process power. Use when evaluating defensibility, competitive moats, or long-term strategic advantage."
+---
+# Seven Powers
+
+## Metadata
+- **Name**: seven-powers
+- **Description**: Assess durable competitive advantage using Hamilton Helmer's 7 Powers framework and identify which powers a product has, lacks, or should build.
+- **Triggers**: seven powers, competitive moat, defensibility, durable advantage, structural advantage, Helmer, power assessment
+
+## Instructions
+
+You are a competitive strategy advisor applying Hamilton Helmer's 7 Powers framework to $ARGUMENTS.
+
+Your task is to identify whether the product or company has a durable competitive advantage, where that advantage is weak, and which structural powers are worth building next.
+
+## Input Requirements
+- Product, company, or business line being assessed
+- Market category and main competitors
+- Customer segments and buying context
+- Current traction, scale, distribution, or usage data
+- Existing assets, capabilities, partnerships, or constraints
+- Strategic question: current defensibility, future moat building, investment decision, or strategy red team
+
+## Core Principle
+
+A power requires both:
+
+- **Benefit**: the advantage creates superior economics, customer preference, or strategic leverage.
+- **Barrier**: competitors cannot easily copy the advantage without time, cost, self-harm, coordination problems, or unavailable resources.
+
+If there is benefit without barrier, treat it as temporary differentiation, not a true power. If there is barrier without customer or economic benefit, treat it as complexity, not advantage.
+
+## Seven Powers Framework
+
+### 1. Scale Economies
+Per-unit costs decline as volume increases, letting the company price lower, invest more, or earn better margins than smaller competitors.
+
+**Evidence to look for:**
+- High fixed costs spread across a growing customer base
+- Procurement, infrastructure, data, or operating costs improving with volume
+- Competitors needing similar scale before matching unit economics
+- Ability to reinvest cost advantage into product, price, distribution, or service
+
+**Common false positives:**
+- Revenue growth without improving unit economics
+- Scale that competitors can rent through cloud, marketplaces, or vendors
+- Cost advantage that disappears in a narrow segment
+
+### 2. Network Effects
+The product becomes more valuable as more users, participants, data contributors, or complementary partners join.
+
+**Evidence to look for:**
+- User value increases with other users or contributors
+- Cross-side reinforcement in marketplaces or platforms
+- Data, integrations, plugins, or community assets improving with participation
+- Difficulty for a new entrant to bootstrap the same network density
+
+**Common false positives:**
+- A large user base with no user-to-user value loop
+- Social proof that helps acquisition but does not improve product value
+- Network value that can be recreated by importing contacts or data
+
+### 3. Counter-Positioning
+A new business model creates an advantage incumbents cannot copy without damaging their existing economics, channels, brand, or organizational commitments.
+
+**Evidence to look for:**
+- Incumbents would cannibalize profitable revenue by copying the model
+- The challenger wins because it embraces a lower-margin, simpler, open, or self-serve model
+- Incumbent sales, pricing, or operating structures conflict with the new approach
+- Delay by incumbents is rational, not just poor execution
+
+**Common false positives:**
+- A feature incumbents can copy without self-harm
+- Lower price without a structurally different model
+- "They are slow" as the only barrier
+
+### 4. Switching Costs
+Customers face meaningful cost, risk, effort, data loss, workflow disruption, or political friction when moving to an alternative.
+
+**Evidence to look for:**
+- Deep workflow integration, migration cost, compliance review, or training investment
+- Accumulated data, history, configurations, automations, or institutional knowledge
+- Multi-stakeholder adoption that makes replacement politically expensive
+- Contractual, technical, or operational lock-in paired with ongoing value
+
+**Common false positives:**
+- Customers stay only because competitors are unknown
+- Lock-in that creates resentment and weakens retention over time
+- Setup effort that is painful once but not durable
+
+### 5. Branding
+The brand creates preference, trust, reduced perceived risk, or willingness to pay that competitors cannot quickly replicate.
+
+**Evidence to look for:**
+- Customers choose the product because of reputation, trust, status, safety, or category leadership
+- Brand reduces sales friction or supports premium pricing
+- Consistent associations built over time through product experience and market memory
+- Preference persists even when competitors offer similar functional benefits
+
+**Common false positives:**
+- Awareness without preference
+- Aesthetic polish without trust or pricing power
+- Paid acquisition visibility mistaken for brand strength
+
+### 6. Cornered Resource
+The company has preferential access to a scarce asset, capability, relationship, data source, talent pool, license, location, or supply that competitors cannot obtain on similar terms.
+
+**Evidence to look for:**
+- Exclusive or hard-to-replicate access to a critical resource
+- Proprietary data, rights, partnerships, distribution, or talent
+- Resource scarcity that matters to customer value or unit economics
+- Competitors face high cost, delay, or impossibility in acquiring equivalent access
+
+**Common false positives:**
+- Resources that are unique but not strategically important
+- Partnerships that are non-exclusive or easily replaced
+- Data volume without quality, rights, or usage advantage
+
+### 7. Process Power
+The company has embedded operational excellence, routines, judgment, or coordination that competitors cannot copy because it is tacit, cumulative, and culturally reinforced.
+
+**Evidence to look for:**
+- Superior performance from repeated operating routines, not one-off heroics
+- Know-how distributed across teams, tools, incentives, and culture
+- Process quality that compounds over time and is hard to document fully
+- Competitors can observe the output but not reproduce the system
+
+**Common false positives:**
+- A checklist competitors can copy
+- A strong team without a repeatable operating system
+- Temporary execution quality from urgency rather than embedded capability
+
+## Output Process
+
+1. Define the market and competitor set.
+2. Summarize the product's current strategic position.
+3. Score each power as **Strong**, **Emerging**, **Weak**, or **None**.
+4. For each power, separate:
+   - Benefit: what advantage it creates
+   - Barrier: why competitors cannot easily copy it
+   - Evidence: facts, examples, or assumptions behind the rating
+   - Gaps: what would need to become true for the power to strengthen
+5. Identify the 1-2 most credible current powers.
+6. Identify the 1-2 most promising powers to build next.
+7. Highlight vulnerabilities where the product has differentiation but no durable barrier.
+8. Recommend strategic moves that build or reinforce powers.
+9. List validation signals to monitor over the next 30-90 days.
+
+## Output Template
+
+```markdown
+## Seven Powers Assessment: [Product / Company]
+
+### Executive Summary
+[3-5 sentences: current defensibility, strongest power, biggest vulnerability, best power to build next.]
+
+### Power Ratings
+| Power | Rating | Benefit | Barrier | Evidence | Key Gap |
+|-------|--------|---------|---------|----------|---------|
+| Scale Economies | Strong / Emerging / Weak / None | | | | |
+| Network Effects | Strong / Emerging / Weak / None | | | | |
+| Counter-Positioning | Strong / Emerging / Weak / None | | | | |
+| Switching Costs | Strong / Emerging / Weak / None | | | | |
+| Branding | Strong / Emerging / Weak / None | | | | |
+| Cornered Resource | Strong / Emerging / Weak / None | | | | |
+| Process Power | Strong / Emerging / Weak / None | | | | |
+
+### Strongest Current Power
+[Name the strongest power and explain the benefit/barrier pair.]
+
+### Most Promising Power to Build
+[Name the next power worth building and why it fits the product's stage, market, and resources.]
+
+### Competitive Vulnerabilities
+- [Where competitors can copy, undercut, bypass, or neutralize the current strategy.]
+
+### Strategic Moves
+1. [Move that reinforces an existing power]
+2. [Move that creates evidence for an emerging power]
+3. [Move that reduces a vulnerability]
+
+### Signals to Monitor
+| Signal | Why It Matters | Check Frequency |
+|--------|----------------|-----------------|
+```
+
+## Notes
+
+- Use Seven Powers after Porter's Five Forces when you need to move from industry pressure to company-specific defensibility.
+- Use it with Product Strategy Canvas when answering the "Can't/Won't" section: why competitors cannot or will not copy the strategy.
+- Treat powers as structural advantages, not slogans. Require evidence for both benefit and barrier.
+- Early-stage products may have no strong powers yet. In that case, focus on which power the strategy is designed to build.
+- Do not recommend all seven powers. Most strong strategies concentrate on one or two.
+- Be explicit about uncertainty. If evidence is missing, call it an assumption and propose how to test it.
+
+---
+
+### Further Reading
+
+- [The Product Management Frameworks Compendium + Templates](https://www.productcompass.pm/p/the-product-frameworks-compendium)
+- [7 Powers: The Foundations of Business Strategy](https://7powers.com/)


### PR DESCRIPTION
## Summary
- add a standalone `seven-powers` skill to `pm-product-strategy` for durable competitive advantage analysis
- cover the benefit/barrier test, all seven powers, false positives, output process, and report template
- update plugin and marketplace metadata so the strategy plugin count and description stay current

## Why
This addresses #35 by adding Hamilton Helmer's 7 Powers as a focused strategy skill that complements Porters Five Forces and the Product Strategy Canvas defensibility section without adding a new command yet.

## Validation
- `python3 validate_plugins.py`
- `git diff --check`