### PR TITLE
feat(opencode): native plugin with auto-discovery for all 68 skills + 42 commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Private maintainer-only files — never commit
 _Internal/
 CLAUDE.local.md
+node_modules

--- a/.opencode/plugins/pm-skills.js
+++ b/.opencode/plugins/pm-skills.js
@@ -1,0 +1,118 @@
+import path from "path";
+import fs from "fs";
+import matter from "gray-matter";
+
+function safeRead(file) {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+const logHelper = (client, message, level = "info") => {
+  client.app.log({
+    body: {
+      service: "opencode-pm-skills",
+      level: level,
+      message,
+    },
+  });
+};
+
+export const PmSkillsPlugin = async (input, _options) => {
+  const { client } = input;
+
+  logHelper(client, "PM Skills plugin initialized");
+
+  const rootDir = path.resolve(__dirname, "../..");
+  logHelper(client, `Scanning root directory: ${rootDir}`);
+
+  const pluginDirs = fs.readdirSync(rootDir).filter((d) => d.startsWith("pm-"));
+  logHelper(
+    client,
+    `Found ${pluginDirs.length} plugin directories: ${pluginDirs.join(", ") || "none"}`,
+  );
+
+  const skillDirs = pluginDirs.map((d) => path.resolve(rootDir, d, "skills"));
+  logHelper(client, `Discovered ${skillDirs.length} skill directories`);
+
+  const commandDirs = pluginDirs.map((d) =>
+    path.resolve(rootDir, d, "commands"),
+  );
+  logHelper(client, `Discovered ${commandDirs.length} command directories`);
+
+  const commands = [];
+  const commandNames = [];
+  for (const dir of commandDirs) {
+    if (!fs.existsSync(dir)) {
+      logHelper(client, `Command directory missing, skipping: ${dir}`, "warn");
+      continue;
+    }
+    const files = fs.readdirSync(dir);
+    logHelper(client, `Scanning ${dir}: ${files.length} files found`);
+    for (const file of files) {
+      if (!file.endsWith(".md")) {
+        logHelper(client, `Skipping non-markdown file: ${file}`, "debug");
+        continue;
+      }
+      const filePath = path.resolve(dir, file);
+      const raw = safeRead(filePath);
+      if (!raw) {
+        logHelper(client, `Failed to read command file: ${filePath}`, "warn");
+        continue;
+      }
+      const parsed = matter(raw);
+      const commandName = path.basename(file, ".md");
+      commands.push({
+        name: commandName,
+        template: parsed.content,
+        data: parsed.data,
+      });
+      commandNames.push(commandName);
+      logHelper(client, `Loaded command: ${commandName}`);
+    }
+  }
+
+  logHelper(client, `Total commands loaded: ${commands.length}`);
+
+  return {
+    config: async (config) => {
+      logHelper(client, "Configuring OpenCode with PM Skills...");
+
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      const addedPaths = [];
+      for (const dir of skillDirs) {
+        if (!config.skills.paths.includes(dir)) {
+          config.skills.paths.push(dir);
+          addedPaths.push(dir);
+        }
+      }
+      if (addedPaths.length > 0) {
+        logHelper(
+          client,
+          `Injected ${addedPaths.length} skill path(s): ${addedPaths.map((p) => path.basename(path.dirname(p))).join(", ")}`,
+        );
+      }
+
+      config.command = config.command || {};
+
+      let registeredCount = 0;
+      for (const cmd of commands) {
+        if (!config.command[cmd.name]) {
+          registeredCount++;
+        }
+        config.command[cmd.name] = {
+          template: cmd.template,
+          ...cmd.data,
+        };
+      }
+      logHelper(
+        client,
+        `Registered ${registeredCount} new command(s), total: ${commands.length} (${commandNames.join(", ")})`,
+      );
+      logHelper(client, "PM Skills plugin configuration complete");
+    },
+  };
+};

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for AI agents (Claude Code, Cowork, and others) working in this reposit
 
 ## Project Overview
 
-**PM Skills** (`phuryn/pm-skills`) — a marketplace of **9 independent plugins** (68 skills, 42 commands) that bring structured product-management workflows to AI coding assistants. Built for Claude Code and Claude Cowork; the skills are also compatible with other agents (Gemini CLI, Cursor, Codex CLI).
+**PM Skills** (`phuryn/pm-skills`) — a marketplace of **9 independent plugins** (68 skills, 42 commands) that bring structured product-management workflows to AI coding assistants. Built for Claude Code and Claude Cowork; the skills are also compatible with other agents (Gemini CLI, Cursor, Codex CLI). OpenCode is supported as a first-class target via a bundled auto-discovery plugin (see [OpenCode Support](#opencode-support)).
 
 Owner: Paweł Huryn — pawel@productcompass.pm — https://www.productcompass.pm
 
@@ -16,6 +16,9 @@ pm-skills/                           <- repo root
 ├── .docs/images/                    <- images used by README (webp, gif)
 ├── .gitattributes
 ├── .gitignore
+├── .opencode/                      <- OpenCode auto-discovery plugin + npm deps
+│   ├── package.json                <- npm manifest (declares gray-matter)
+│   └── plugins/pm-skills.js        <- plugin that registers all PM skills + commands
 ├── CLAUDE.md                        <- this file (agent guidance, single source of truth)
 ├── AGENTS.md                        <- pointer to CLAUDE.md (for non-Claude agents)
 ├── CONTRIBUTING.md                  <- contributor guidelines
@@ -67,6 +70,19 @@ pm-skills/                           <- repo root
 
 Descriptions in `plugin.json` and the repo `README.md` should stay aligned (identical text).
 
+## OpenCode Support
+
+This repo ships a bundled OpenCode plugin (`.opencode/plugins/pm-skills.js`) so the same skills and commands work in OpenCode with no manual copying.
+
+At startup it:
+- Scans the repo root for `pm-*` directories.
+- Injects each plugin's `skills/` path into `config.skills.paths` — OpenCode then lazy-loads skills from those paths.
+- Parses every `commands/*.md` file (via `gray-matter` frontmatter) and registers it under `config.command`, so the same `/slash` commands are available.
+
+It is self-bootstrapping: adding, removing, or editing skills and commands anywhere under `pm-*/skills/` or `pm-*/commands/` is picked up automatically on the next OpenCode start — no `.opencode/` edits required.
+
+Runtime dependency: `gray-matter` (declared in `.opencode/package.json`). Install once with `npm install` inside `.opencode/`; `node_modules/` is gitignored.
+
 ## Versioning
 
 - All versions are currently **2.0.0** — `marketplace.json` and all 9 `plugin.json` files.
@@ -87,6 +103,7 @@ Descriptions in `plugin.json` and the repo `README.md` should stay aligned (iden
 2. If skills/commands were added or removed, update the counts in `README.md`.
 3. If totals changed, update the count in the `marketplace.json` description.
 4. Bump versions across all manifests (see Versioning).
+5. No OpenCode sync needed — the bundled `.opencode/plugins/pm-skills.js` re-scans `pm-*/skills/` and `pm-*/commands/` on startup (just ensure `npm install` has run in `.opencode/` once).
 
 ### After a description change
 - A `plugin.json` description changed → check whether `README.md` needs the same edit (they stay aligned).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # PM Skills Marketplace: The AI Operating System for Better Product Decisions
 
-> 68 PM skills and 42 chained workflows across 9 plugins. Claude Code, Cowork, and more. From discovery to strategy, execution, launch, growth, and shipping AI-built code.
+> 68 PM skills and 42 chained workflows across 9 plugins. Claude Code, Cowork, and more. From discovery to strategy, execution, launch, growth, and shipping AI-built code. 
 
 ![PM Skills marketplace: skills, commands, and all 9 plugins at a glance](.docs/images/plugins.png)
 
@@ -33,7 +33,7 @@ The result: better product decisions, not just faster documents.
 
 ![Example prompts: a skill and two commands (/write-prd, /ship-check) in action](.docs/images/examples.png)
 
-**Skills** are the building blocks of the marketplace. Each skill gives Claude domain knowledge, analytical frameworks, or a guided workflow for a specific PM task. Some skills also work as reusable foundations that multiple commands share.
+**Skills** are the building blocks of the marketplace. Each skill gives Claude domain knowledge, analytical frameworks, or a guided workflow for a specific PM task. Some skills also work as reusable foundations that multiple commands share. 
 
 Skills are loaded automatically when relevant to the conversation — no explicit invocation needed. If needed (e.g., prioritizing skills over general knowledge), you can **force loading skills** with `/plugin-name:skill-name` or `/skill-name` (Claude will add the prefix).
 
@@ -67,8 +67,8 @@ claude plugin marketplace add phuryn/pm-skills
 # Step 2: Install individual plugins
 claude plugin install pm-toolkit@pm-skills
 claude plugin install pm-product-strategy@pm-skills
-claude plugin install pm-product-discovery@pm-skills
-claude plugin install pm-market-research@pm-skills
+claude plugin install pm-product-discovery@pm-skills 
+claude plugin install pm-market-research@pm-skills 
 claude plugin install pm-data-analytics@pm-skills
 claude plugin install pm-marketing-growth@pm-skills
 claude plugin install pm-go-to-market@pm-skills
@@ -100,7 +100,7 @@ codex plugin add pm-ai-shipping@pm-skills
 
 **What's different from Claude Code:** the `/slash` commands (`/discover`, `/write-prd`, …) install but don't run as Codex slash commands — Codex plugins don't expose commands. To run a workflow, just describe the steps in plain language, for example:
 
-> Run product discovery on _[your idea]_: brainstorm options, map assumptions, prioritize the risky ones, then design experiments — pause between each step.
+> Run product discovery on *[your idea]*: brainstorm options, map assumptions, prioritize the risky ones, then design experiments — pause between each step.
 
 **Optional — let Codex turn the workflows into skills.** Because the command files ship inside each installed plugin, you can ask Codex to convert the ones you use most:
 
@@ -124,13 +124,13 @@ OpenCode ships with a native plugin bundled in this repo (`.opencode/plugins/pm-
 
 ### Other AI assistants
 
-The `skills/*/SKILL.md` files follow the universal skill format and work with any tool that reads it. `/slash-commands` are Claude-specific and don't run as native commands in these tools.
+The `skills/*/SKILL.md` files follow the universal skill format and work with any tool that reads it. `/slash-commands` are Claude-specific everywhere except OpenCode, where the bundled plugin below registers them automatically.
 
-| Tool           | How to use                              | What works  |
-| -------------- | --------------------------------------- | ----------- |
+| Tool | How to use | What works |
+|------|-----------|------------|
 | **Gemini CLI** | Copy skill folders to `.gemini/skills/` | Skills only |
-| **Cursor**     | Copy skill folders to `.cursor/skills/` | Skills only |
-| **Kiro**       | Copy skill folders to `.kiro/skills/`   | Skills only |
+| **Cursor** | Copy skill folders to `.cursor/skills/` | Skills only |
+| **Kiro** | Copy skill folders to `.kiro/skills/` | Skills only |
 
 ```bash
 # Example: copy all skills for Gemini CLI (global)
@@ -173,13 +173,11 @@ done
 **Examples:**
 
 Skills:
-
 - `What are the riskiest assumptions for our AI writing assistant idea?`
 - `Help me build an Opportunity Solution Tree for improving user activation`
 - `Prioritize these 12 feature requests from our enterprise customers [attach CSV]`
 
 Commands:
-
 - `/discover AI-powered meeting summarizer for remote teams`
 - `/brainstorm experiments existing — We need to reduce churn in our onboarding flow`
 - `/interview prep — We're interviewing enterprise buyers about their procurement workflow`
@@ -217,13 +215,11 @@ Product strategy, vision, business models, pricing, and macro environment analys
 **Examples:**
 
 Skills:
-
 - `Compare Lean Canvas vs Business Model Canvas vs Startup Canvas for my marketplace startup`
 - `Design a value proposition for our AI writing assistant targeting non-native English speakers`
 - `Run a Porter's Five Forces analysis for the project management SaaS market`
 
 Commands:
-
 - `/strategy B2B project management tool for agencies`
 - `/business-model startup — AI writing tool for non-native English speakers`
 - `/value-proposition SaaS onboarding tool for enterprise customers`
@@ -271,13 +267,11 @@ Day-to-day product management: PRDs, OKRs, roadmaps, sprints, retrospectives, re
 **Examples:**
 
 Skills:
-
 - `Which prioritization framework should I use for a 50-item backlog?`
 - `Map our stakeholders for the platform migration project`
 - `What's the difference between Opportunity Score, ICE, and RICE?`
 
 Commands:
-
 - `/write-prd Smart notification system that reduces alert fatigue`
 - `/sprint retro — Here are the notes from our last sprint`
 - `/write-stories job — Break down the "team dashboard" feature into job stories`
@@ -308,13 +302,11 @@ User research and competitive analysis: personas, segmentation, journey maps, ma
 **Examples:**
 
 Skills:
-
 - `Estimate TAM/SAM/SOM for an AI code review tool in the US market`
 - `Create a customer journey map for our e-commerce checkout flow`
 - `Segment these survey respondents by behavior and needs [attach CSV]`
 
 Commands:
-
 - `/research-users We have interview data from 12 users of our fitness app`
 - `/competitive-analysis Figma competitors in the design tool space`
 - `/analyze-feedback Here's 200 NPS responses from Q4 [attach file]`
@@ -341,12 +333,10 @@ Data analytics for PMs: SQL query generation, cohort analysis, and A/B test anal
 **Examples:**
 
 Skills:
-
 - `How large a sample do I need for 95% confidence with a 2% MDE?`
 - `What retention metrics should I track for a subscription app?`
 
 Commands:
-
 - `/write-query Show me monthly active users by country for Q4 2025 (BigQuery)`
 - `/analyze-test Here are the results from our checkout flow A/B test [attach CSV]`
 - `/analyze-cohorts Weekly retention for users who signed up in January vs February`
@@ -376,13 +366,11 @@ Go-to-market strategy: beachhead segments, ideal customer profiles, messaging, g
 **Examples:**
 
 Skills:
-
 - `What's the best beachhead segment for a developer productivity tool?`
 - `Design a growth loop for a B2B SaaS with a freemium tier`
 - `Define our ICP for an AI-powered HR screening platform`
 
 Commands:
-
 - `/plan-launch AI code review tool targeting mid-size engineering teams`
 - `/battlecard Our CRM vs Salesforce for the SMB market`
 - `/growth-strategy Two-sided marketplace for connecting freelancers with startups`
@@ -410,13 +398,11 @@ Product marketing and growth: marketing ideas, positioning, value proposition st
 **Examples:**
 
 Skills:
-
 - `Brainstorm 5 positioning angles that differentiate us from Notion`
 - `What's a good North Star Metric for a two-sided marketplace?`
 - `Generate value prop statements for our sales team's pitch deck`
 
 Commands:
-
 - `/market-product B2B analytics dashboard for e-commerce managers`
 - `/north-star Two-sided marketplace connecting freelancers with clients`
 
@@ -445,12 +431,10 @@ PM utilities beyond core product work: resume review, legal documents, and proof
 **Examples:**
 
 Skills:
-
 - `Review my PM resume against best practices [attach PDF]`
 - `Check this product announcement for grammar and clarity`
 
 Commands:
-
 - `/review-resume [attach your PM resume]`
 - `/tailor-resume [attach resume + paste job description]`
 - `/proofread Here's the draft of our Q1 investor update`
@@ -460,7 +444,7 @@ Commands:
 <details>
 <summary><strong>9. pm-ai-shipping</strong> — AI Shipping Kit: document a vibe-coded app, audit security and performance, map test coverage, compile a shipping packet (2 skills, 5 commands)</summary>
 
-For PMs and founders accountable for AI-built code. AI agents write code fast but leave no record of _intent_ — what the system should do, who may do what, where the secrets live, which rules are actually verified. This kit restores reviewability: it documents the system, then audits the gap between what the docs say and what the code actually does — the class of bug generic scanners miss.
+For PMs and founders accountable for AI-built code. AI agents write code fast but leave no record of *intent* — what the system should do, who may do what, where the secrets live, which rules are actually verified. This kit restores reviewability: it documents the system, then audits the gap between what the docs say and what the code actually does — the class of bug generic scanners miss.
 
 **Skills (2):**
 
@@ -478,12 +462,10 @@ For PMs and founders accountable for AI-built code. AI agents write code fast bu
 **Examples:**
 
 Skills:
-
 - `What documentation does my Supabase app need before someone can review it?`
 - `Where does what this code does diverge from what the docs say it should do?`
 
 Commands:
-
 - `/ship-check the payments service`
 - `/document-app — Reverse-engineer the system docs for this repo`
 - `/derive-tests — Which documented rules have no test yet?`
@@ -499,18 +481,18 @@ This marketplace evolves with product practice and AI capabilities.
 
 Selected skills based on the work of:
 
-- Teresa Torres — [_Continuous Discovery Habits_](https://www.amazon.com/Continuous-Discovery-Habits-Discover-Products/dp/1736633309/)
-- Marty Cagan — [_INSPIRED_](https://www.amazon.com/INSPIRED-Create-Tech-Products-Customers/dp/1119387507/) and [_TRANSFORMED_](https://www.amazon.com/dp/1119697336/)
-- Alberto Savoia — [_The Right It_](https://www.amazon.com/Right-Many-Ideas-Yours-Succeed/dp/0062884654)
-- Dan Olsen — [_The Lean Product Playbook_](https://www.amazon.com/dp/1118960874/)
-- Roger L. Martin — [_Playing to Win_](https://www.amazon.com/Playing-Win-Expanded-Bonus-Articles/dp/B0F25SDYWV/)
-- Ash Maurya — [_Running Lean_](https://www.amazon.com/dp/B004J4XGN6/)
-- Strategyzer — [_Business Model Generation_](https://www.amazon.com/dp/0470876417/) and [_Value Proposition Design_](https://www.amazon.com/dp/1118968050/)
-- Christina Wodtke — [_Radical Focus_](https://www.amazon.com/Radical-Focus-Achieving-Important-Objectives/dp/0996006052)
-- Anthony W. Ulwick — [_Jobs to Be Done_](https://jobs-to-be-done-book.com/)
-- Alistair Croll & Benjamin Yoskovitz — [_Lean Analytics_](https://www.amazon.com/Lean-Analytics-Better-Startup-Faster/dp/1449335675/)
-- Sean Ellis — [_Hacking Growth_](https://www.amazon.com/Hacking-Growth-Fastest-Growing-Companies-Breakout/dp/045149721X/)
-- Maja Voje — [_Go-To-Market Strategist_](https://gtmstrategist.com/)
+- Teresa Torres — [*Continuous Discovery Habits*](https://www.amazon.com/Continuous-Discovery-Habits-Discover-Products/dp/1736633309/)
+- Marty Cagan — [*INSPIRED*](https://www.amazon.com/INSPIRED-Create-Tech-Products-Customers/dp/1119387507/) and [*TRANSFORMED*](https://www.amazon.com/dp/1119697336/)
+- Alberto Savoia — [*The Right It*](https://www.amazon.com/Right-Many-Ideas-Yours-Succeed/dp/0062884654)
+- Dan Olsen — [*The Lean Product Playbook*](https://www.amazon.com/dp/1118960874/)
+- Roger L. Martin — [*Playing to Win*](https://www.amazon.com/Playing-Win-Expanded-Bonus-Articles/dp/B0F25SDYWV/)
+- Ash Maurya — [*Running Lean*](https://www.amazon.com/dp/B004J4XGN6/)
+- Strategyzer — [*Business Model Generation*](https://www.amazon.com/dp/0470876417/) and [*Value Proposition Design*](https://www.amazon.com/dp/1118968050/)
+- Christina Wodtke — [*Radical Focus*](https://www.amazon.com/Radical-Focus-Achieving-Important-Objectives/dp/0996006052)
+- Anthony W. Ulwick — [*Jobs to Be Done*](https://jobs-to-be-done-book.com/)
+- Alistair Croll & Benjamin Yoskovitz — [*Lean Analytics*](https://www.amazon.com/Lean-Analytics-Better-Startup-Faster/dp/1449335675/)
+- Sean Ellis — [*Hacking Growth*](https://www.amazon.com/Hacking-Growth-Fastest-Growing-Companies-Breakout/dp/045149721X/)
+- Maja Voje — [*Go-To-Market Strategist*](https://gtmstrategist.com/)
 
 Curated by Paweł Huryn from [The Product Compass Newsletter](https://www.productcompass.pm).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # PM Skills Marketplace: The AI Operating System for Better Product Decisions
 
-> 68 PM skills and 42 chained workflows across 9 plugins. Claude Code, Cowork, and more. From discovery to strategy, execution, launch, growth, and shipping AI-built code. 
+> 68 PM skills and 42 chained workflows across 9 plugins. Claude Code, Cowork, and more. From discovery to strategy, execution, launch, growth, and shipping AI-built code.
 
 ![PM Skills marketplace: skills, commands, and all 9 plugins at a glance](.docs/images/plugins.png)
 
@@ -33,7 +33,7 @@ The result: better product decisions, not just faster documents.
 
 ![Example prompts: a skill and two commands (/write-prd, /ship-check) in action](.docs/images/examples.png)
 
-**Skills** are the building blocks of the marketplace. Each skill gives Claude domain knowledge, analytical frameworks, or a guided workflow for a specific PM task. Some skills also work as reusable foundations that multiple commands share. 
+**Skills** are the building blocks of the marketplace. Each skill gives Claude domain knowledge, analytical frameworks, or a guided workflow for a specific PM task. Some skills also work as reusable foundations that multiple commands share.
 
 Skills are loaded automatically when relevant to the conversation — no explicit invocation needed. If needed (e.g., prioritizing skills over general knowledge), you can **force loading skills** with `/plugin-name:skill-name` or `/skill-name` (Claude will add the prefix).
 
@@ -67,8 +67,8 @@ claude plugin marketplace add phuryn/pm-skills
 # Step 2: Install individual plugins
 claude plugin install pm-toolkit@pm-skills
 claude plugin install pm-product-strategy@pm-skills
-claude plugin install pm-product-discovery@pm-skills 
-claude plugin install pm-market-research@pm-skills 
+claude plugin install pm-product-discovery@pm-skills
+claude plugin install pm-market-research@pm-skills
 claude plugin install pm-data-analytics@pm-skills
 claude plugin install pm-marketing-growth@pm-skills
 claude plugin install pm-go-to-market@pm-skills
@@ -100,7 +100,7 @@ codex plugin add pm-ai-shipping@pm-skills
 
 **What's different from Claude Code:** the `/slash` commands (`/discover`, `/write-prd`, …) install but don't run as Codex slash commands — Codex plugins don't expose commands. To run a workflow, just describe the steps in plain language, for example:
 
-> Run product discovery on *[your idea]*: brainstorm options, map assumptions, prioritize the risky ones, then design experiments — pause between each step.
+> Run product discovery on _[your idea]_: brainstorm options, map assumptions, prioritize the risky ones, then design experiments — pause between each step.
 
 **Optional — let Codex turn the workflows into skills.** Because the command files ship inside each installed plugin, you can ask Codex to convert the ones you use most:
 
@@ -108,24 +108,31 @@ codex plugin add pm-ai-shipping@pm-skills
 
 This is a best-effort, model-driven conversion (some Claude-specific command syntax won't translate), but it's a quick way to get the guided workflows on Codex without leaving the CLI.
 
-### Other AI assistants (skills only)
+### OpenCode
 
-The `skills/*/SKILL.md` files follow the universal skill format and work with any tool that reads it. Commands (`/slash-commands`) are Claude-specific.
+OpenCode ships with a native plugin bundled in this repo (`.opencode/plugins/pm-skills.js`), which auto-registers every skill and `/slash` command.
 
-| Tool | How to use | What works |
-|------|-----------|------------|
+```jsonc
+# Add the plugin to your opencode plugin config
+{
+  "plugin": ["pm-skills@git+https://github.com/phuryn/pm-skills.git"]
+}
+# Then restart opencode.
+```
+
+**What you get:** every skill (the PM frameworks) **and** every `/slash` command (`/discover`, `/write-prd`, …), both registered automatically by the bundled plugin.
+
+### Other AI assistants
+
+The `skills/*/SKILL.md` files follow the universal skill format and work with any tool that reads it. `/slash-commands` are Claude-specific and don't run as native commands in these tools.
+
+| Tool           | How to use                              | What works  |
+| -------------- | --------------------------------------- | ----------- |
 | **Gemini CLI** | Copy skill folders to `.gemini/skills/` | Skills only |
-| **OpenCode** | Copy skill folders to `.opencode/skills/` | Skills only |
-| **Cursor** | Copy skill folders to `.cursor/skills/` | Skills only |
-| **Kiro** | Copy skill folders to `.kiro/skills/` | Skills only |
+| **Cursor**     | Copy skill folders to `.cursor/skills/` | Skills only |
+| **Kiro**       | Copy skill folders to `.kiro/skills/`   | Skills only |
 
 ```bash
-# Example: copy all skills for OpenCode (project-level)
-for plugin in pm-*/; do
-  mkdir -p .opencode/skills/
-  cp -r "$plugin/skills/"* .opencode/skills/ 2>/dev/null
-done
-
 # Example: copy all skills for Gemini CLI (global)
 for plugin in pm-*/; do
   cp -r "$plugin/skills/"* ~/.gemini/skills/ 2>/dev/null
@@ -166,11 +173,13 @@ done
 **Examples:**
 
 Skills:
+
 - `What are the riskiest assumptions for our AI writing assistant idea?`
 - `Help me build an Opportunity Solution Tree for improving user activation`
 - `Prioritize these 12 feature requests from our enterprise customers [attach CSV]`
 
 Commands:
+
 - `/discover AI-powered meeting summarizer for remote teams`
 - `/brainstorm experiments existing — We need to reduce churn in our onboarding flow`
 - `/interview prep — We're interviewing enterprise buyers about their procurement workflow`
@@ -208,11 +217,13 @@ Product strategy, vision, business models, pricing, and macro environment analys
 **Examples:**
 
 Skills:
+
 - `Compare Lean Canvas vs Business Model Canvas vs Startup Canvas for my marketplace startup`
 - `Design a value proposition for our AI writing assistant targeting non-native English speakers`
 - `Run a Porter's Five Forces analysis for the project management SaaS market`
 
 Commands:
+
 - `/strategy B2B project management tool for agencies`
 - `/business-model startup — AI writing tool for non-native English speakers`
 - `/value-proposition SaaS onboarding tool for enterprise customers`
@@ -260,11 +271,13 @@ Day-to-day product management: PRDs, OKRs, roadmaps, sprints, retrospectives, re
 **Examples:**
 
 Skills:
+
 - `Which prioritization framework should I use for a 50-item backlog?`
 - `Map our stakeholders for the platform migration project`
 - `What's the difference between Opportunity Score, ICE, and RICE?`
 
 Commands:
+
 - `/write-prd Smart notification system that reduces alert fatigue`
 - `/sprint retro — Here are the notes from our last sprint`
 - `/write-stories job — Break down the "team dashboard" feature into job stories`
@@ -295,11 +308,13 @@ User research and competitive analysis: personas, segmentation, journey maps, ma
 **Examples:**
 
 Skills:
+
 - `Estimate TAM/SAM/SOM for an AI code review tool in the US market`
 - `Create a customer journey map for our e-commerce checkout flow`
 - `Segment these survey respondents by behavior and needs [attach CSV]`
 
 Commands:
+
 - `/research-users We have interview data from 12 users of our fitness app`
 - `/competitive-analysis Figma competitors in the design tool space`
 - `/analyze-feedback Here's 200 NPS responses from Q4 [attach file]`
@@ -326,10 +341,12 @@ Data analytics for PMs: SQL query generation, cohort analysis, and A/B test anal
 **Examples:**
 
 Skills:
+
 - `How large a sample do I need for 95% confidence with a 2% MDE?`
 - `What retention metrics should I track for a subscription app?`
 
 Commands:
+
 - `/write-query Show me monthly active users by country for Q4 2025 (BigQuery)`
 - `/analyze-test Here are the results from our checkout flow A/B test [attach CSV]`
 - `/analyze-cohorts Weekly retention for users who signed up in January vs February`
@@ -359,11 +376,13 @@ Go-to-market strategy: beachhead segments, ideal customer profiles, messaging, g
 **Examples:**
 
 Skills:
+
 - `What's the best beachhead segment for a developer productivity tool?`
 - `Design a growth loop for a B2B SaaS with a freemium tier`
 - `Define our ICP for an AI-powered HR screening platform`
 
 Commands:
+
 - `/plan-launch AI code review tool targeting mid-size engineering teams`
 - `/battlecard Our CRM vs Salesforce for the SMB market`
 - `/growth-strategy Two-sided marketplace for connecting freelancers with startups`
@@ -391,11 +410,13 @@ Product marketing and growth: marketing ideas, positioning, value proposition st
 **Examples:**
 
 Skills:
+
 - `Brainstorm 5 positioning angles that differentiate us from Notion`
 - `What's a good North Star Metric for a two-sided marketplace?`
 - `Generate value prop statements for our sales team's pitch deck`
 
 Commands:
+
 - `/market-product B2B analytics dashboard for e-commerce managers`
 - `/north-star Two-sided marketplace connecting freelancers with clients`
 
@@ -424,10 +445,12 @@ PM utilities beyond core product work: resume review, legal documents, and proof
 **Examples:**
 
 Skills:
+
 - `Review my PM resume against best practices [attach PDF]`
 - `Check this product announcement for grammar and clarity`
 
 Commands:
+
 - `/review-resume [attach your PM resume]`
 - `/tailor-resume [attach resume + paste job description]`
 - `/proofread Here's the draft of our Q1 investor update`
@@ -437,7 +460,7 @@ Commands:
 <details>
 <summary><strong>9. pm-ai-shipping</strong> — AI Shipping Kit: document a vibe-coded app, audit security and performance, map test coverage, compile a shipping packet (2 skills, 5 commands)</summary>
 
-For PMs and founders accountable for AI-built code. AI agents write code fast but leave no record of *intent* — what the system should do, who may do what, where the secrets live, which rules are actually verified. This kit restores reviewability: it documents the system, then audits the gap between what the docs say and what the code actually does — the class of bug generic scanners miss.
+For PMs and founders accountable for AI-built code. AI agents write code fast but leave no record of _intent_ — what the system should do, who may do what, where the secrets live, which rules are actually verified. This kit restores reviewability: it documents the system, then audits the gap between what the docs say and what the code actually does — the class of bug generic scanners miss.
 
 **Skills (2):**
 
@@ -455,10 +478,12 @@ For PMs and founders accountable for AI-built code. AI agents write code fast bu
 **Examples:**
 
 Skills:
+
 - `What documentation does my Supabase app need before someone can review it?`
 - `Where does what this code does diverge from what the docs say it should do?`
 
 Commands:
+
 - `/ship-check the payments service`
 - `/document-app — Reverse-engineer the system docs for this repo`
 - `/derive-tests — Which documented rules have no test yet?`
@@ -474,18 +499,18 @@ This marketplace evolves with product practice and AI capabilities.
 
 Selected skills based on the work of:
 
-- Teresa Torres — [*Continuous Discovery Habits*](https://www.amazon.com/Continuous-Discovery-Habits-Discover-Products/dp/1736633309/)
-- Marty Cagan — [*INSPIRED*](https://www.amazon.com/INSPIRED-Create-Tech-Products-Customers/dp/1119387507/) and [*TRANSFORMED*](https://www.amazon.com/dp/1119697336/)
-- Alberto Savoia — [*The Right It*](https://www.amazon.com/Right-Many-Ideas-Yours-Succeed/dp/0062884654)
-- Dan Olsen — [*The Lean Product Playbook*](https://www.amazon.com/dp/1118960874/)
-- Roger L. Martin — [*Playing to Win*](https://www.amazon.com/Playing-Win-Expanded-Bonus-Articles/dp/B0F25SDYWV/)
-- Ash Maurya — [*Running Lean*](https://www.amazon.com/dp/B004J4XGN6/)
-- Strategyzer — [*Business Model Generation*](https://www.amazon.com/dp/0470876417/) and [*Value Proposition Design*](https://www.amazon.com/dp/1118968050/)
-- Christina Wodtke — [*Radical Focus*](https://www.amazon.com/Radical-Focus-Achieving-Important-Objectives/dp/0996006052)
-- Anthony W. Ulwick — [*Jobs to Be Done*](https://jobs-to-be-done-book.com/)
-- Alistair Croll & Benjamin Yoskovitz — [*Lean Analytics*](https://www.amazon.com/Lean-Analytics-Better-Startup-Faster/dp/1449335675/)
-- Sean Ellis — [*Hacking Growth*](https://www.amazon.com/Hacking-Growth-Fastest-Growing-Companies-Breakout/dp/045149721X/)
-- Maja Voje — [*Go-To-Market Strategist*](https://gtmstrategist.com/)
+- Teresa Torres — [_Continuous Discovery Habits_](https://www.amazon.com/Continuous-Discovery-Habits-Discover-Products/dp/1736633309/)
+- Marty Cagan — [_INSPIRED_](https://www.amazon.com/INSPIRED-Create-Tech-Products-Customers/dp/1119387507/) and [_TRANSFORMED_](https://www.amazon.com/dp/1119697336/)
+- Alberto Savoia — [_The Right It_](https://www.amazon.com/Right-Many-Ideas-Yours-Succeed/dp/0062884654)
+- Dan Olsen — [_The Lean Product Playbook_](https://www.amazon.com/dp/1118960874/)
+- Roger L. Martin — [_Playing to Win_](https://www.amazon.com/Playing-Win-Expanded-Bonus-Articles/dp/B0F25SDYWV/)
+- Ash Maurya — [_Running Lean_](https://www.amazon.com/dp/B004J4XGN6/)
+- Strategyzer — [_Business Model Generation_](https://www.amazon.com/dp/0470876417/) and [_Value Proposition Design_](https://www.amazon.com/dp/1118968050/)
+- Christina Wodtke — [_Radical Focus_](https://www.amazon.com/Radical-Focus-Achieving-Important-Objectives/dp/0996006052)
+- Anthony W. Ulwick — [_Jobs to Be Done_](https://jobs-to-be-done-book.com/)
+- Alistair Croll & Benjamin Yoskovitz — [_Lean Analytics_](https://www.amazon.com/Lean-Analytics-Better-Startup-Faster/dp/1449335675/)
+- Sean Ellis — [_Hacking Growth_](https://www.amazon.com/Hacking-Growth-Fastest-Growing-Companies-Breakout/dp/045149721X/)
+- Maja Voje — [_Go-To-Market Strategist_](https://gtmstrategist.com/)
 
 Curated by Paweł Huryn from [The Product Compass Newsletter](https://www.productcompass.pm).
 

--- a/docs/opencode-auto-discovery-plugin.md
+++ b/docs/opencode-auto-discovery-plugin.md
@@ -1,0 +1,38 @@
+# Proposal: a bundled OpenCode plugin so PM Skills just works
+
+OpenCode is the one first-class target with no native PM Skills path. This proposes shipping a small plugin inside the repo (`.opencode/plugins/pm-skills.js`) that auto-registers every skill and `/slash` command at runtime — one-line install, nothing to copy, nothing to keep in sync.
+
+## Today's gap
+
+OpenCode can't read the Claude-style `marketplace.json`, so right now its users get the worst deal of any supported assistant. Skills have to be hand-copied into OpenCode's skill paths with no source of truth — every plugin update means re-copying and risking drift. The 42 guided workflows (`/discover`, `/write-prd`, `/red-team-prd`, …) don't register at all, since nothing turns `commands/*.md` into real OpenCode commands. And there's no incremental story: add a skill upstream, and every OpenCode user has to redo their setup.
+
+## What I'm proposing
+
+A repo-bundled plugin (npm manifest in `.opencode/package.json`, depends on `gray-matter`) that, on init, does the boring work itself:
+
+1. Scans the repo root for `pm-*/` dirs (the 9 plugins).
+2. Pushes each `pm-*/skills/` path into `config.skills.paths` — OpenCode then lazily discovers every `SKILL.md`. No symlinks, no config edits. This works because `Config.get()` is a cached singleton, so the mutation is visible when skills get resolved later.
+3. Frontmatter-parses every `pm-*/commands/*.md` and registers it as `config.command[name] = { template, ...data }`.
+4. Logs init / scan / load / totals under `opencode-pm-skills` so setup is observable instead of silent.
+
+The skill and command files stay the single source of truth — on `git pull`, new ones just show up.
+
+### Install
+
+```jsonc
+{
+  "plugin": ["pm-skills@git+https://github.com/phuryn/pm-skills.git"]
+}
+```
+
+Then restart OpenCode.
+
+## What you get
+
+All 68 skills and 42 commands, native; one-line install; stays in sync.
+
+## Verification
+
+- Plugin logs `Found 9 plugin directories`.
+- 9 paths land in `config.skills.paths`; 42 commands register in `config.command`.
+- `/write-prd` and the `create-prd` skill resolve in a fresh session.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pm-skills",
+  "type": "module",
+  "private": true,
+  "main": ".opencode/plugins/pm-skills.js",
+  "dependencies": {
+    "gray-matter": "^4.0.3"
+  }
+}


### PR DESCRIPTION
## What this does

Gives OpenCode first-class PM Skills support. Until now it was the only major target with no native path — users had to hand-copy `skills/` folders, re-do it on every update, and still got none of the `/slash` command workflows. This PR ships a bundled plugin that auto-registers everything at runtime: one-line install, nothing to copy, stays in sync on `git pull`.

## What's in here

**`.opencode/plugins/pm-skills.js`** — the plugin itself. On init it scans `pm-*/` dirs at the repo root, injects each `pm-*/skills/` path into `config.skills.paths` (OpenCode lazily discovers every `SKILL.md` — no symlinks, no config edits; works because `Config.get()` is a cached singleton), frontmatter-parses `pm-*/commands/*.md` with `gray-matter`, and registers each as `config.command[name]`. Structured logging throughout (init / scan / per-command load / totals) under the `opencode-pm-skills` service so setup is observable.

**`package.json`** — root npm manifest. OpenCode reads the root `package.json` to find the plugin entry point; without it the plugin doesn't load. Declares `gray-matter` as a dependency.

**`README.md`** — adds the OpenCode install section with the one-line config snippet, plus formatting consistency fixes.

**`CLAUDE.md`** — updates the repo structure docs and the OpenCode reference in the project overview.

**`.gitignore`** — ignores `node_modules/` for the plugin's npm deps.

**`docs/opencode-auto-discovery-plugin.md`** — written proposal capturing the design (gap, approach, install, verification) for record and discussion.

## How to review

The plugin file is the core — read `.opencode/plugins/pm-skills.js` first. The rest is wiring (package.json at root so OpenCode finds the entry point), docs (README + CLAUDE.md sections), and the proposal. 13 commits because this was iterated to working state (rename, package.json location, default→named export, formatting) — the final state is what matters.

## Install

```jsonc
{
  "plugin": ["pm-skills@git+https://github.com/phuryn/pm-skills.git"]
}
```

Then restart OpenCode.

## Verification

- Plugin loads and logs `Found 9 plugin directories`.
- All 9 `pm-*/skills/` paths land in `config.skills.paths`.
- All 42 `pm-*/commands/*.md` register in `config.command` (one per file).
- `/write-prd` and the `create-prd` skill resolve and invoke in a fresh OpenCode session.

## Result

All 68 skills + 42 `/slash` commands available natively. One-line install. Stays in sync with the repo on `git pull` — no manual copying, no drift.