### PR TITLE
docs: add Qoder skill installation guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Repo
-
-- Documented project-level Qoder skill installation. (#57, thanks @phodal)
-
 ## v2.1.0 — 2026-07-03
 
 ### pm-ai-shipping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Repo
+
+- Documented project-level Qoder skill installation. (#57, thanks @phodal)
+
 ## v2.1.0 — 2026-07-03
 
 ### pm-ai-shipping

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The `skills/*/SKILL.md` files follow the universal skill format and work with an
 | **OpenCode** | Copy skill folders to `.opencode/skills/` | Skills only |
 | **Cursor** | Copy skill folders to `.cursor/skills/` | Skills only |
 | **Kiro** | Copy skill folders to `.kiro/skills/` | Skills only |
+| **Qoder** | Copy skill folders to `.qoder/skills/` | Skills only |
 
 ```bash
 # Example: copy all skills for OpenCode (project-level)


### PR DESCRIPTION
## Summary

- add Qoder to the **Other AI assistants (skills only)** table
- document `.qoder/skills/` as the project-level installation path

## Why

PM Skills already uses the universal `SKILL.md` format supported by Qoder. A skills-only entry is the smallest useful integration and matches the installation guidance for the other assistants in this section, without introducing or maintaining a separate Qoder plugin manifest for all nine plugins.

## User impact

Qoder users can copy any PM skill folder into `.qoder/skills/` and use it at the project level. Claude-specific slash commands remain out of scope.

## Validation

- `python3 validate_plugins.py`
- `python3 -m unittest discover -s tests`
- `git diff --check`